### PR TITLE
use clap to parse dot commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,11 @@ impl From<OnOff> for bool {
 }
 
 #[derive(Debug, Clone, Parser)]
-#[command(multicall = true, disable_help_subcommand = true, help_template = "{all-args}")]
+#[command(
+    no_binary_name = true,
+    disable_help_subcommand = true,
+    help_template = "{all-args}"
+)]
 enum DotCommand {
     /// Print this message or the help of the given subcommand(s).
     #[command(name = ".help")]
@@ -147,7 +151,7 @@ impl App {
 
         match DotCommand::try_parse_from(clap_args) {
             Ok(DotCommand::Help { subcommand: None }) => {
-                DotCommand::command().print_help()?;
+                DotCommand::command().disable_help_flag(true).print_help()?;
                 Ok(())
             }
             Ok(DotCommand::Help {
@@ -159,7 +163,9 @@ impl App {
                 if let Some(subcommand) = DotCommand::command().find_subcommand_mut(name) {
                     subcommand.print_help()?;
                 } else {
-                    DotCommand::command().print_help()?;
+                    DotCommand::command()
+                        .disable_help_subcommand(true)
+                        .print_help()?;
                 }
                 Ok(())
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ impl From<OnOff> for bool {
 }
 
 #[derive(Debug, Clone, Parser)]
-#[command(multicall = true, disable_help_subcommand = true)]
+#[command(multicall = true, disable_help_subcommand = true, help_template = "{all-args}")]
 enum DotCommand {
     /// Print this message or the help of the given subcommand(s).
     #[command(name = ".help")]

--- a/src/output.rs
+++ b/src/output.rs
@@ -45,7 +45,7 @@ impl<'f> WriteColor for WriteColorFile<'f> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum OutputMode {
     Null,
     Table,


### PR DESCRIPTION
Get nice help output, typo suggestions, and the like:
![image](https://user-images.githubusercontent.com/1006268/193048653-eb57ee4c-cd66-452b-94da-bc7c71de6527.png)


Here it's implemented as a fake multicall CLI. It's a bit janky as can be seen in the screenshot (with the -- suggestions). there might be a better approach